### PR TITLE
Fix: Maintenance cleanup - docs and auto-creation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -268,17 +268,18 @@ The MCP server provides 25+ tools across 7 categories:
 
 ```
 professor-oak/
-├── CLAUDE.md              # Instructions for Claude
+├── CLAUDE.md              # Instructions for Claude (root)
 ├── .claudeignore          # Protected files list
-├── .mcp.json              # MCP server configuration
-├── trainer.yaml           # Global trainer profile (MCP-managed)
-├── pokedex.yaml           # Global Pokemon collection (MCP-managed)
-├── quiz-history/          # Monthly quiz records
-│   └── YYYY-MM.yaml
-├── mcp/                   # MCP server source
-├── personas/              # Character persona files
-├── topics/                # Learning content
-└── docs/                  # Documentation
+├── docs/                  # Documentation
+├── topics/                # Learning content (auto-created)
+└── src/
+    ├── CLAUDE.md          # Persona system instructions
+    ├── .mcp.json          # MCP server configuration
+    ├── trainer.yaml       # Global trainer profile (MCP-managed, auto-created)
+    ├── pokedex.yaml       # Global Pokemon collection (MCP-managed, auto-created)
+    ├── quiz-history/      # Monthly quiz records
+    │   └── YYYY-MM.yaml
+    └── mcp-server/        # MCP server source
 ```
 
 ### Topic Structure
@@ -311,7 +312,7 @@ topics/[topic]/
 ### MCP Server Structure
 
 ```
-mcp/professor-oak-mcp/
+src/mcp-server/
 ├── src/
 │   ├── index.ts           # Server entry point
 │   ├── tools/
@@ -427,7 +428,7 @@ CMD ["node", "dist/index.js"]
 
 ### Adding New Tools
 
-1. Create tool in `mcp/professor-oak-mcp/src/tools/`
+1. Create tool in `src/mcp-server/src/tools/`
 2. Register in `index.ts`
 3. Update CLAUDE.md with usage instructions
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -14,7 +14,7 @@ This guide covers contributing to Professor Oak, extending the MCP server, and w
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/professor-oak.git
+git clone https://github.com/tomblancdev/professor-oak.git
 cd professor-oak
 
 # Open in VS Code with devcontainers
@@ -25,7 +25,7 @@ code .
 ### Manual Development (Without VS Code)
 
 ```bash
-cd mcp/professor-oak-mcp
+cd src/mcp-server
 
 # Install dependencies
 docker run --rm -v $(pwd):/app -w /app node:20-alpine npm ci
@@ -44,27 +44,27 @@ docker run --rm -v $(pwd):/app -w /app node:20-alpine npm run dev
 
 ```
 professor-oak/
-├── CLAUDE.md                 # Claude instructions (critical file)
-├── .mcp.json                 # MCP configuration
+├── CLAUDE.md                 # Claude instructions (root)
 ├── .claudeignore             # Protected files
-├── mcp/
-│   └── professor-oak-mcp/    # MCP server
-│       ├── src/
-│       │   ├── index.ts      # Entry point
-│       │   ├── tools/        # Tool implementations
-│       │   ├── services/     # Shared services
-│       │   ├── types/        # TypeScript interfaces
-│       │   └── config/       # Constants and configs
-│       ├── Dockerfile
-│       ├── package.json
-│       └── tsconfig.json
 ├── .claude/
 │   ├── commands/             # Slash command definitions
 │   ├── hooks/                # Pre-commit hooks
 │   └── settings.json         # Hook configuration
-├── personas/                 # Character persona files
+├── docs/                     # Documentation
 ├── topics/                   # Learning content (auto-generated)
-└── docs/                     # Documentation
+└── src/
+    ├── CLAUDE.md             # Persona system instructions
+    ├── .mcp.json             # MCP configuration
+    └── mcp-server/           # MCP server
+        ├── src/
+        │   ├── index.ts      # Entry point
+        │   ├── tools/        # Tool implementations
+        │   ├── services/     # Shared services
+        │   ├── types/        # TypeScript interfaces
+        │   └── config/       # Constants and configs
+        ├── Dockerfile
+        ├── package.json
+        └── tsconfig.json
 ```
 
 ## Adding New Topics
@@ -136,7 +136,7 @@ milestones: []
 1. **Create the tool file** (or add to existing category):
 
 ```typescript
-// mcp/professor-oak-mcp/src/tools/my-tool.ts
+// src/mcp-server/src/tools/my-tool.ts
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 
@@ -169,7 +169,7 @@ export function registerMyTools(server: McpServer) {
 2. **Register in index.ts**:
 
 ```typescript
-// mcp/professor-oak-mcp/src/index.ts
+// src/mcp-server/src/index.ts
 import { registerMyTools } from "./tools/my-tool.js";
 
 // ... in server setup
@@ -195,7 +195,7 @@ registerMyTools(server);
 ### Example: Adding a Leaderboard Tool
 
 ```typescript
-// mcp/professor-oak-mcp/src/tools/leaderboard.ts
+// src/mcp-server/src/tools/leaderboard.ts
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { readYaml } from "../services/yaml.js";
@@ -361,7 +361,7 @@ Use neutral/celebratory tone, no specific persona required.
 ### Running Tests
 
 ```bash
-cd mcp/professor-oak-mcp
+cd src/mcp-server
 
 # Run all tests
 docker run --rm -v $(pwd):/app -w /app node:20-alpine npm run test:run
@@ -376,7 +376,7 @@ docker run --rm -v $(pwd):/app -w /app node:20-alpine npm test
 ### Writing Tests
 
 ```typescript
-// mcp/professor-oak-mcp/src/__tests__/my-tool.test.ts
+// src/mcp-server/src/__tests__/my-tool.test.ts
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { readYaml, writeYaml } from "../services/yaml.js";
 
@@ -464,7 +464,7 @@ Edit `.github/workflows/ci.yml`:
 ```yaml
 - name: My Custom Check
   run: |
-    cd mcp/professor-oak-mcp
+    cd src/mcp-server
     docker run --rm -v $(pwd):/app -w /app node:20-alpine npm run my-check
 ```
 
@@ -518,7 +518,7 @@ return jsonResponse({
 ### Development Build
 
 ```bash
-cd mcp/professor-oak-mcp
+cd src/mcp-server
 docker build -t professor-oak-mcp:dev .
 ```
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -455,11 +455,11 @@ Wild encounters are high risk/high reward:
 
 Save them for topics you're confident in.
 
-### 5. Save Extra Learnings
+### 5. Save Extra Learnings (Coming Soon)
 
-When you learn something interesting in conversation:
-1. Use `/save` to capture it
-2. Take the optional quiz
+When `/save` is available, you'll be able to:
+1. Capture interesting learnings from conversation
+2. Take an optional quiz
 3. Catch a bonus Pokemon!
 
 ### 6. Review for Evolution

--- a/src/mcp-server/src/__tests__/pokedex.test.ts
+++ b/src/mcp-server/src/__tests__/pokedex.test.ts
@@ -276,11 +276,12 @@ describe("Pokedex Tools", () => {
       expect(result.filtersApplied).toEqual({ topic: "docker", level: "beginner" });
     });
 
-    it("should return error when pokedex.yaml does not exist", async () => {
+    it("should auto-create pokedex.yaml when it does not exist", async () => {
       const result = await getPokedex({});
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain("Failed to read");
+      expect(result.success).toBe(true);
+      expect(result.pokemon).toEqual([]);
+      expect(result.stats.total_caught).toBe(0);
     });
   });
 

--- a/src/mcp-server/src/__tests__/trainer.test.ts
+++ b/src/mcp-server/src/__tests__/trainer.test.ts
@@ -142,11 +142,13 @@ describe("Trainer Tools", () => {
       expect(result.point_history).toHaveLength(2);
     });
 
-    it("should return error when trainer.yaml does not exist", async () => {
+    it("should auto-create trainer.yaml when it does not exist", async () => {
       const result = await getTrainer({});
 
-      expect(result.success).toBe(false);
-      expect(result.error).toContain("Failed to read");
+      expect(result.success).toBe(true);
+      expect(result.name).toBeNull();
+      expect(result.rank).toBe("Rookie Trainer");
+      expect(result.totalPoints).toBe(0);
     });
   });
 

--- a/src/mcp-server/src/tools/trainer.ts
+++ b/src/mcp-server/src/tools/trainer.ts
@@ -6,7 +6,7 @@
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { readYaml, writeYaml } from "../services/yaml.js";
+import { readYaml, writeYaml, fileExists } from "../services/yaml.js";
 import { TRAINER_RANKS } from "../config/constants.js";
 import { calculateRank, pointsToNextRank } from "../services/points.js";
 import type { TrainerData, PointHistoryEntry } from "../types/trainer.js";
@@ -17,6 +17,29 @@ import type { TrainerData, PointHistoryEntry } from "../types/trainer.js";
 export async function getTrainer(input: {
   includeHistory?: boolean;
 }): Promise<any> {
+  // Initialize trainer.yaml if it doesn't exist
+  const exists = await fileExists("trainer.yaml");
+  if (!exists) {
+    const initialTrainer: TrainerData = {
+      version: 1,
+      trainer: null,
+      started_at: null,
+      total_points: 0,
+      rank: "Rookie Trainer",
+      settings: {
+        wild_encounters: true,
+        notifications: true,
+      },
+      achievements: {
+        first_pokemon: null,
+        first_badge: null,
+        first_legendary: null,
+      },
+      point_history: [],
+    };
+    await writeYaml("trainer.yaml", initialTrainer, "Professor Oak - Trainer");
+  }
+
   const result = await readYaml<TrainerData>("trainer.yaml");
 
   if (!result.success) {


### PR DESCRIPTION
## Summary

Maintenance cleanup based on QA testing feedback:

### Documentation fixes:
- Fix Tip #5 in user-guide.md to properly mark `/save` as Coming Soon
- Fix all `mcp/professor-oak-mcp` paths → `src/mcp-server` in developer-guide.md (10 occurrences)
- Fix `yourusername` → `tomblancdev` in developer-guide.md
- Fix project structure diagrams in developer-guide.md and architecture.md
- Fix `mcp/` paths in architecture.md

### Code improvements:
- Add auto-creation to `trainer.ts` (matching `pokedex.ts` behavior)
- Both trainer.yaml and pokedex.yaml now auto-initialize on first use
- Update tests to expect auto-creation behavior

## Test plan
- [x] All 203 tests pass
- [x] trainer.ts auto-creates trainer.yaml like pokedex.ts
- [x] Documentation paths are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)