### PR TITLE
fix: cross-platform grep command in setup guide

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -36,12 +36,20 @@ docker build -t professor-oak-mcp:latest --target runtime .
 
 Verify the build:
 ```bash
+# Linux/macOS
 docker images | grep professor-oak-mcp
+
+# Windows (PowerShell)
+docker images | findstr professor-oak-mcp
+
+# Cross-platform alternative
+docker images professor-oak-mcp
 ```
 
 Expected output:
 ```
-professor-oak-mcp   latest    abc123def456   Just now   150MB
+REPOSITORY          TAG       IMAGE ID       CREATED        SIZE
+professor-oak-mcp   latest    abc123def456   Just now       150MB
 ```
 
 ### Step 3: Configure Claude


### PR DESCRIPTION
## Summary

Fixes the grep command in the setup guide to work cross-platform (Linux, macOS, Windows).

Closes #37

## Type of Change

- [x] Bug fix

## Changes Made

- Added Windows PowerShell `findstr` alternative
- Added cross-platform `docker images professor-oak-mcp` option
- Updated expected output format to match actual docker output

## Testing

- [x] Documentation verified for accuracy

## Checklist

- [x] Code follows project style
- [x] Documentation updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)