### PR TITLE
fix: use current directory for MCP volume mount

### DIFF
--- a/src/.mcp.json
+++ b/src/.mcp.json
@@ -4,7 +4,7 @@
       "command": "docker",
       "args": [
         "run", "--rm", "-i",
-        "-v", "${workspaceFolder}:/data:rw",
+        "-v", ".:/data:rw",
         "professor-oak-mcp:latest"
       ]
     }


### PR DESCRIPTION
## Summary

Changes the MCP volume mount from `${workspaceFolder}` to `.` for better portability.

Closes #38

## Type of Change

- [x] Bug fix

## Changes Made

- Updated `src/.mcp.json` to use `.:/data:rw` instead of `${workspaceFolder}:/data:rw`

## Testing

- [x] Configuration verified

## Checklist

- [x] Code follows project style

🤖 Generated with [Claude Code](https://claude.com/claude-code)