### PR TITLE
fix: Replace grep with cross-platform alternative in setup guide

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -36,12 +36,20 @@ docker build -t professor-oak-mcp:latest --target runtime .
 
 Verify the build:
 ```bash
+# Linux/macOS
 docker images | grep professor-oak-mcp
+
+# Windows (PowerShell)
+docker images | findstr professor-oak-mcp
+
+# Cross-platform alternative
+docker images professor-oak-mcp
 ```
 
 Expected output:
 ```
-professor-oak-mcp   latest    abc123def456   Just now   150MB
+REPOSITORY          TAG       IMAGE ID       CREATED        SIZE
+professor-oak-mcp   latest    abc123def456   Just now       150MB
 ```
 
 ### Step 3: Configure Claude


### PR DESCRIPTION
Closes #37

## Summary
- Added Windows PowerShell `findstr` alternative for checking Docker image build
- Added cross-platform `docker images professor-oak-mcp` option that works everywhere
- Updated expected output format with proper column headers

## Changes
The setup guide previously only showed `docker images | grep professor-oak-mcp` which doesn't work on Windows. Now provides three options:
1. Linux/macOS: `docker images | grep professor-oak-mcp`
2. Windows (PowerShell): `docker images | findstr professor-oak-mcp`
3. Cross-platform: `docker images professor-oak-mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)