### PR TITLE
fix: prevent evolution of tier 5 (Legendary) Pokemon

### DIFF
--- a/src/mcp-server/src/__tests__/pokedex.test.ts
+++ b/src/mcp-server/src/__tests__/pokedex.test.ts
@@ -712,6 +712,41 @@ describe("Pokedex Tools", () => {
       expect(pokedexData.stats.by_topic.docker).toBe(2);
       expect(pokedexData.stats.total_caught).toBe(2);
     });
+
+    it("should reject evolution of tier 5 (Legendary) Pokemon", async () => {
+      await createPokedexFile({
+        pokemon: [
+          {
+            id: "pokemon-001",
+            pokedex_number: 150,
+            name: "Mewtwo",
+            sprites: { front: "https://example.com/mewtwo.png" },
+            topic: "docker",
+            course: "01-introduction",
+            level: "expert",
+            tier: 5,
+            caught_at: "2026-01-11",
+            caught_during: "quiz",
+          },
+        ],
+        stats: {
+          total_caught: 1,
+          total_evolved: 0,
+          legendaries: 1,
+          by_topic: { docker: 1 },
+        },
+      });
+
+      const result = await evolvePokemon({
+        pokemonId: "pokemon-001",
+        evolvedPokedexNumber: 151,
+        evolvedName: "Super Mewtwo",
+        evolvedSprites: { front: "https://example.com/super-mewtwo.png" },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Legendary Pokemon cannot evolve further");
+    });
   });
 
   describe("getPokedexStats", () => {

--- a/src/mcp-server/src/tools/pokedex.ts
+++ b/src/mcp-server/src/tools/pokedex.ts
@@ -194,6 +194,15 @@ export async function evolvePokemon(input: {
     };
   }
 
+
+  // Check if Pokemon is already at max tier (Legendary - tier 5)
+  if (originalPokemon.tier >= 5) {
+    return {
+      success: false,
+      error: "Legendary Pokemon cannot evolve further - they have reached maximum tier",
+    };
+  }
+
   // Generate next ID
   const nextNumber = data.pokemon.length + 1;
   const evolvedId = `pokemon-${String(nextNumber).padStart(3, "0")}`;


### PR DESCRIPTION
## Summary

- Adds validation to prevent evolution of tier 5 (Legendary) Pokemon
- Returns clear error message: "Legendary Pokemon cannot evolve further - they have reached maximum tier"

## Changes

- `src/mcp-server/src/tools/pokedex.ts` - Added tier validation in `evolvePokemon` function
- `src/mcp-server/src/__tests__/pokedex.test.ts` - Added test for tier 5 evolution rejection

## Test plan

- [x] All 227 tests pass
- [x] New test verifies tier 5 Pokemon cannot evolve

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)