### PR TITLE
fix: validate folder structure in initializeLevel

### DIFF
--- a/src/mcp-server/src/tools/topic.ts
+++ b/src/mcp-server/src/tools/topic.ts
@@ -283,6 +283,20 @@ export function registerTopicTools(server: McpServer) {
         });
       }
 
+      // Verify folder structure exists before proceeding
+      const levelCoursePath = path.join(getDataPath(), `topics/${topic}/courses/${level}`);
+      const levelExercisePath = path.join(getDataPath(), `topics/${topic}/exercices/${level}`);
+
+      try {
+        await fs.access(levelCoursePath);
+        await fs.access(levelExercisePath);
+      } catch {
+        return jsonResponse({
+          success: false,
+          error: `Topic folder structure incomplete for level "${level}". Run createTopic first.`,
+        });
+      }
+
       // Update progress.yaml
       data.current_level = level;
       data.roadmap[level] = {


### PR DESCRIPTION
## Summary
- Adds validation to `initializeLevel` to check folder structure exists
- Verifies `courses/{level}` and `exercices/{level}` directories exist
- Returns clear error message if structure is incomplete

Closes #77

## Test plan
- [x] Build passes
- [x] All 253 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)