### PR TITLE
feat: add Zod schema validation to yaml service

### DIFF
--- a/src/mcp-server/src/services/yaml.ts
+++ b/src/mcp-server/src/services/yaml.ts
@@ -8,6 +8,7 @@
 import * as fs from "fs/promises";
 import * as path from "path";
 import YAML from "yaml";
+import { z } from "zod";
 
 /**
  * Get the data path from environment variable.
@@ -17,11 +18,21 @@ function getDataPath(): string {
   return process.env.DATA_PATH || "/data";
 }
 
+/**
+ * Result type for YAML operations
+ */
 export interface YamlResult<T> {
   success: boolean;
   data?: T;
   error?: string;
 }
+
+/**
+ * Result type for validated YAML reads
+ */
+export type ValidatedYamlResult<T> =
+  | { success: true; data: T }
+  | { success: false; error: string; validationErrors?: z.ZodIssue[] };
 
 /**
  * Read a YAML file and parse it
@@ -32,6 +43,38 @@ export async function readYaml<T>(relativePath: string): Promise<YamlResult<T>> 
     const content = await fs.readFile(fullPath, "utf-8");
     const data = YAML.parse(content) as T;
     return { success: true, data };
+  } catch (error) {
+    return {
+      success: false,
+      error: `Failed to read ${relativePath}: ${error}`
+    };
+  }
+}
+
+/**
+ * Read a YAML file, parse it, and validate against a Zod schema.
+ * Returns detailed validation errors if the data doesn't match the schema.
+ */
+export async function readYamlWithSchema<T>(
+  relativePath: string,
+  schema: z.ZodType<T>
+): Promise<ValidatedYamlResult<T>> {
+  try {
+    const fullPath = path.join(getDataPath(), relativePath);
+    const content = await fs.readFile(fullPath, "utf-8");
+    const parsed = YAML.parse(content);
+    
+    // Validate with Zod schema
+    const result = schema.safeParse(parsed);
+    if (!result.success) {
+      return {
+        success: false,
+        error: `Invalid data in ${relativePath}: ${result.error.issues.map(i => i.message).join(", ")}`,
+        validationErrors: result.error.issues,
+      };
+    }
+    
+    return { success: true, data: result.data };
   } catch (error) {
     return {
       success: false,


### PR DESCRIPTION
## Summary
Adds schema validation capability to the YAML service using Zod:

- **New function**: `readYamlWithSchema<T>(path, schema)` - reads and validates YAML against a Zod schema
- **New type**: `ValidatedYamlResult<T>` - includes `validationErrors` array with field-level details
- Existing `readYaml` unchanged for backward compatibility

Example usage:
```typescript
const schema = z.object({ name: z.string(), value: z.number() });
const result = await readYamlWithSchema("config.yaml", schema);
if (!result.success) {
  console.log(result.validationErrors); // Detailed field-level errors
}
```

Closes #58

## Test plan
- [x] Build passes
- [x] All 253 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)